### PR TITLE
Fix import statement and remove dependancy on account_accountant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,13 @@ Payroll Payments for Odoo
 Easily record payments on Payslips as easily as you can on employee expenses.
 
 
+============
+Dependencies
+============
+* account_accountant_cbc - https://github.com/CubicERP/apps
+
+
+
 ========
 Features
 ========

--- a/hr_payroll_payment/__init__.py
+++ b/hr_payroll_payment/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-import hr_payroll_register_payment
+from . import hr_payroll_register_payment

--- a/hr_payroll_payment/__manifest__.py
+++ b/hr_payroll_payment/__manifest__.py
@@ -11,7 +11,7 @@
 Adds the ability to register a payment on a payslip.
     """,
     'website': 'https://hibou.io/',
-    'depends': ['hr_payroll_account', 'account_accountant'],
+    'depends': ['hr_payroll_account'],
     'data': [
         'hr_payroll_register_payment.xml',
     ],

--- a/hr_payroll_payment/__manifest__.py
+++ b/hr_payroll_payment/__manifest__.py
@@ -11,7 +11,7 @@
 Adds the ability to register a payment on a payslip.
     """,
     'website': 'https://hibou.io/',
-    'depends': ['hr_payroll_account'],
+    'depends': ['hr_payroll_account', 'account_accountant_cbc'],
     'data': [
         'hr_payroll_register_payment.xml',
     ],


### PR DESCRIPTION
Hi I made some adjustments to allow this to work on odoo 11.
- Needed the 'from . import' otherwise I got an error when trying to install the module.
- Module 'account_accountant' no longer exists, but it's not needed as it's all in the default install anyway.